### PR TITLE
TODO:使用bcsub来计算接口请求开始到结束的时间

### DIFF
--- a/Applications/Statistics/Clients/StatisticClient.php
+++ b/Applications/Statistics/Clients/StatisticClient.php
@@ -62,7 +62,7 @@ class StatisticClient
             $time_start = microtime(true);
         }
          
-        $cost_time = microtime(true) - $time_start;
+        $cost_time = bcsub(microtime(true), $time_start, 4);
         
         $bin_data = StatisticProtocol::encode($module, $interface, $cost_time, $success, $code, $msg);
         


### PR DESCRIPTION
1 使用bcsub来进行通信时间长短计算,避免出现 3.0E-6, 因通信时间太短而产生的计算BUG.
